### PR TITLE
#4 fix some other usability issues that came up while testing

### DIFF
--- a/src/App_Plugins/U2/managementdashboard.controller.js
+++ b/src/App_Plugins/U2/managementdashboard.controller.js
@@ -15,21 +15,25 @@
         $scope.isLoading = false;
 
 
-        twoFactorService.getTOTPAuthenticatorSetupCode().then(function (response) {
-            $scope.qrCodeUri = response.data.QrCodeUri;
-            $scope.secret = response.data.Secret;
-            $scope.email = response.data.Email;
-            $scope.applicationName = response.data.ApplicationName;
+        var setupSignup = function () {
+            twoFactorService.getTOTPAuthenticatorSetupCode().then(function (response) {
+                $scope.qrCodeUri = response.data.QrCodeUri;
+                $scope.secret = response.data.Secret;
+                $scope.email = response.data.Email;
+                $scope.applicationName = response.data.ApplicationName;
 
-            var typeNumber = 0;
-            var errorCorrectionLevel = 'H';
-            var qr = qrcode(typeNumber, errorCorrectionLevel);
-            qr.addData(response.data.QrCodeUri);
-            qr.make();
-            document.getElementById('qrcode').innerHTML = qr.createSvgTag(5);
-        });
+                var typeNumber = 0;
+                var errorCorrectionLevel = 'H';
+                var qr = qrcode(typeNumber, errorCorrectionLevel);
+                qr.addData(response.data.QrCodeUri);
+                qr.make();
+                document.getElementById('qrcode').innerHTML = qr.createSvgTag(5);
+            });
+        }
+        setupSignup();
 
         var getEnabledUserSettings = function () {
+            console.log('refreshing enabled user list');
             $scope.isLoading = true;
             twoFactorService.getEnabledUserSettings().then(function (response) {
                 console.log('Got Users:', response.data);
@@ -82,6 +86,12 @@
                         $scope.enabledText = "enabled";
                         $scope.enabled = true;
                         $scope.TOTPAuthEnabled = true;
+                        $scope.code = '';
+
+                        // refresh the list of users with MFA enabled
+                        if ($scope.isAdmin) {
+                            getEnabledUserSettings();
+                        }
                     } else {
                         $scope.error2FA = "Invalid code entered.";
                     }
@@ -101,13 +111,13 @@
                         $scope.enabled = false;
                         $scope.TOTPAuthEnabled = false;
 
-                        twoFactorService.getTOTPAuthenticatorSetupCode().then(function (response) {
+                        // Setup the TOTP Setup again
+                        setupSignup()
 
-                            $scope.qrCodeUri = response.data.QrCodeUri;
-                            $scope.secret = response.data.Secret;
-                            $scope.email = response.data.Email;
-                            $scope.applicationName = response.data.ApplicationName;
-                        });
+                        // refresh the list of users with MFA enabled
+                        if ($scope.isAdmin) {
+                            getEnabledUserSettings();
+                        }
                     } else {
                         $scope.error2FA = "You don't have permission to do this action, please contact your administrator.";
                     }

--- a/src/Controllers/U2AuthController.cs
+++ b/src/Controllers/U2AuthController.cs
@@ -5,6 +5,7 @@ using U2.Models;
 using U2.Services;
 using Umbraco.Web.WebApi;
 using System.Collections.Generic;
+using System.Web;
 
 namespace U2.Controllers
 {
@@ -35,10 +36,10 @@ namespace U2.Controllers
             var user = Security.CurrentUser;
             byte[] secretKey = KeyGeneration.GenerateRandomKey(20);
             string secret = Base32Encoding.ToString(secretKey);
-            string userName = user.Username;
+            string userName = HttpUtility.UrlEncode(user.Username);
 
-            string issuer = System.Configuration.ConfigurationManager.AppSettings["TOTPIssuer"] ?? "U2";
-            string qrCodeUri = $"otpauth://totp/{issuer}:{userName}?secret={secret}&issuer={issuer}" ;
+            string issuer = HttpUtility.UrlEncode(System.Configuration.ConfigurationManager.AppSettings["TOTPIssuer"] ?? "U2");
+            string qrCodeUri = $"otpauth://totp/{issuer}:{userName}?secret={secret}&issuer={issuer}&digits=6" ;
 
             var twoFactorAuthInfo = new U2MFASetup();
             twoFactorAuthInfo.Email = user.Email;

--- a/src/u2.nuspec
+++ b/src/u2.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>U2</id>
-    <version>1.0.2</version>
+    <version>1.1.1-alpha002</version>
     <authors>Evan Moore</authors>
     <owners>Evan Moore</owners>
     <projectUrl>https://github.com/cleversolutions/U2</projectUrl>


### PR DESCRIPTION
closes #4 
Refreshes the list of enabled users when the admin removes themselves
UrlEncodes the information which is necessary for MS Authenticator to work
Fixed another problem where the QR code wasn't properly generated after disabling MFA. 
You should now be able to enable then disable then enable again without refreshing the browser.

@timeverts if you could test this on U3 that would be great. You can create a nuget package by cloning the repository, cd into the src directory and run .\nuget.exe pack. Add a nuget source in VS to this project (or copy the nuget package to a local nuget repository if you already have one setup) and update your Umbraco project use the alpha version of this package (you have to include pre-release packages since it's an alpha).

Thanks,
Evan